### PR TITLE
Add disconnect-based host switching for non-divertable keyboards with Logitech MX 4

### DIFF
--- a/src/cleverswitch/factory.py
+++ b/src/cleverswitch/factory.py
@@ -1,5 +1,5 @@
 from .hidpp.constants import FEATURE_CHANGE_HOST, FEATURE_REPROG_CONTROLS_V4
-from .hidpp.protocol import resolve_feature_index
+from .hidpp.protocol import get_host_info, resolve_feature_index
 from .hidpp.transport import HIDTransport, log
 from .model import LogiProduct
 
@@ -31,6 +31,12 @@ def _make_logi_product(
         feat_idx,
     )
 
+    num_hosts = 0
+    host_info = get_host_info(transport, slot, feat_idx)
+    if host_info:
+        num_hosts, current_host = host_info
+        log.debug("%s (slot=0x%02X) host info: num_hosts=%d, current_host=%d", name, slot, num_hosts, current_host)
+
     feat_idx_rep = None
     if role == "keyboard":
         feat_idx_rep = resolve_feature_index(transport, slot, FEATURE_REPROG_CONTROLS_V4)
@@ -59,4 +65,5 @@ def _make_logi_product(
         divert_feat_idx=feat_idx_rep,
         role=role,
         name=name,
+        num_hosts=num_hosts,
     )

--- a/src/cleverswitch/hidpp/protocol.py
+++ b/src/cleverswitch/hidpp/protocol.py
@@ -75,7 +75,7 @@ def request(
     devnumber: int,
     request_id: int,
     *params,
-    timeout: int = 500,
+    timeout: int = 2000,
 ) -> bytes | None:
     """Send a HID++ request and return the reply payload.
 
@@ -181,7 +181,7 @@ def resolve_feature_index(
         feature_code >> 8,
         feature_code & 0xFF,
         0x00,
-        timeout=500,
+        timeout=2000,
     )
     if reply and reply[0] != 0x00:
         return reply[0]
@@ -199,7 +199,7 @@ def get_device_name(
     Returns the marketing name (e.g. 'MX Keys'), or None on failure.
     """
     # fn [0]: getDeviceNameCount — returns total name length (no terminating zero)
-    reply = request(transport, devnumber, (feat_idx << 8) | 0x00, timeout=500)
+    reply = request(transport, devnumber, (feat_idx << 8) | 0x00, timeout=2000)
     if not reply:
         return None
     name_len = reply[0]
@@ -209,7 +209,7 @@ def get_device_name(
     # fn [1]: getDeviceName(charIndex) — returns chunk starting at charIndex
     chars: list[int] = []
     while len(chars) < name_len:
-        reply = request(transport, devnumber, (feat_idx << 8) | 0x10, len(chars), timeout=500)
+        reply = request(transport, devnumber, (feat_idx << 8) | 0x10, len(chars), timeout=2000)
         if not reply:
             break
         remaining = name_len - len(chars)
@@ -233,9 +233,24 @@ def get_device_type(
     or None on failure.
     """
     request_id = (feat_idx << 8) | 0x20  # function [2]
-    reply = request(transport, devnumber, request_id, timeout=500)
+    reply = request(transport, devnumber, request_id, timeout=2000)
     if reply:
         return reply[0]
+    return None
+
+
+def get_host_info(
+    transport: HIDTransport,
+    devnumber: int,
+    feature_idx: int,
+) -> tuple[int, int] | None:
+    """Call x1814 getHostInfo [fn 0] to read numHosts and currentHost.
+
+    Returns (num_hosts, current_host) or None on failure.
+    """
+    reply = request(transport, devnumber, (feature_idx << 8) | 0x00, timeout=2000)
+    if reply and len(reply) >= 2:
+        return reply[0], reply[1]
     return None
 
 

--- a/src/cleverswitch/listeners.py
+++ b/src/cleverswitch/listeners.py
@@ -11,9 +11,13 @@ from .hidpp.constants import (
     DEVICE_TYPE_MOUSE,
     DEVICE_TYPE_TRACKBALL,
     DEVICE_TYPE_TRACKPAD,
+    DJ_DEVICE_PAIRING,
     FEATURE_DEVICE_TYPE_AND_NAME,
+    HID_DEVICE_PAIRING,
     HOST_SWITCH_CIDS,
+    REPORT_DJ,
     REPORT_LONG,
+    REPORT_SHORT,
     SW_ID,
 )
 from .hidpp.protocol import get_device_name, get_device_type, resolve_feature_index, send_change_host, set_cid_divert
@@ -21,6 +25,7 @@ from .hidpp.transport import HidDeviceInfo, HIDTransport
 from .model import (
     BaseEvent,
     ConnectionEvent,
+    DisconnectionEvent,
     ExternalUndivertEvent,
     HostChangeEvent,
     LogiProduct,
@@ -149,7 +154,9 @@ class ReceiverListener(BaseListener):
                     self._handle_connection(ConnectionEvent(slot))
 
     def _handle_event(self, event: BaseEvent) -> None:
-        if isinstance(event, ConnectionEvent):
+        if isinstance(event, DisconnectionEvent):
+            self._handle_disconnection(event)
+        elif isinstance(event, ConnectionEvent):
             if event.slot not in self._products:
                 log.debug("Adding product for slot=%d", event.slot)
                 self._add_product(event.slot)
@@ -159,14 +166,50 @@ class ReceiverListener(BaseListener):
         elif isinstance(event, ExternalUndivertEvent):
             self._handle_external_undivert(event)
 
+    def _handle_disconnection(self, event: DisconnectionEvent) -> None:
+        product = self._products.get(event.slot)
+        if product is None:
+            return
+        product.connected = False
+        log.info("Device disconnected: slot=%d name=%s", product.slot, product.name)
+        if product.num_hosts < 2:
+            return
+        # Switch all other CONNECTED products to host 1 (the other Mac).
+        target_host = 1
+        log.info("Switching other devices to host %d", target_host)
+        for entry in self._registry.all_entries():
+            if entry.devnumber == event.slot:
+                continue
+            other = self._products.get(entry.devnumber)
+            if other and not other.connected:
+                continue  # already disconnected, skip
+            log.debug("Sending CHANGE_HOST to %s (slot=%d) target_host=%d", entry.name, entry.devnumber, target_host)
+            try:
+                send_change_host(entry.transport, entry.devnumber, entry.change_host_feat_idx, target_host)
+            except Exception as e:
+                log.debug("Host switch failed for %s: %s", entry.name, e)
+
     def _handle_connection(self, event: ConnectionEvent) -> None:
         product = self._products.get(event.slot)
         if product is None:
             return
+        product.connected = True
         log.debug(f"Product reconnected slot={product.slot} name={product.name}")
         if product.divert_feat_idx is not None:
             log.debug(f"Sending divert host switch keys request for slot={product.slot} name={product.name}")
             _divert_all_es_keys(self._transport, product)
+        # Bring back other devices that are still disconnected.
+        for entry in self._registry.all_entries():
+            if entry.devnumber == event.slot:
+                continue
+            other = self._products.get(entry.devnumber)
+            if other and other.connected:
+                continue  # already here, skip
+            log.info("Bringing back %s (slot=%d) to host 0", entry.name, entry.devnumber)
+            try:
+                send_change_host(entry.transport, entry.devnumber, entry.change_host_feat_idx, 0)
+            except Exception as e:
+                log.debug("Host switch failed for %s: %s", entry.name, e)
 
     def _handle_external_undivert(self, event: ExternalUndivertEvent) -> None:
         product = self._products.get(event.slot)
@@ -284,6 +327,18 @@ def parse_message(raw: bytes, products: dict[int, LogiProduct] | None = None) ->
     slot = raw[1]
     feature_id = raw[2]
     function_id = raw[3]
+
+    # DJ pairing report: detect device disconnect/connect
+    if report_id == REPORT_DJ and feature_id == DJ_DEVICE_PAIRING:
+        if function_id & 0x40:  # disconnect flag
+            return DisconnectionEvent(slot)
+        return ConnectionEvent(slot)
+
+    # HID++ 1.0 short pairing notification (Bolt on macOS)
+    if report_id == REPORT_SHORT and feature_id == HID_DEVICE_PAIRING and len(raw) >= 5:
+        if raw[4] & 0x40:  # disconnect flag
+            return DisconnectionEvent(slot)
+        return None  # connect handled by x1D4B long notification
 
     if report_id != REPORT_LONG:
         return None

--- a/src/cleverswitch/model.py
+++ b/src/cleverswitch/model.py
@@ -21,6 +21,11 @@ class ConnectionEvent(BaseEvent):
 
 
 @dataclass
+class DisconnectionEvent(BaseEvent):
+    slot: int
+
+
+@dataclass
 class ExternalUndivertEvent(BaseEvent):
     target_host_cid: int
 
@@ -34,6 +39,7 @@ class LogiProduct:
     divert_feat_idx: int | None
     role: str  # "keyboard" or "mouse"
     name: str
+    num_hosts: int = 0
     connected: bool = False
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -9,18 +9,21 @@ from cleverswitch.factory import _make_logi_product
 
 def test_make_logi_product_returns_none_when_change_host_not_supported(mocker, fake_transport):
     mocker.patch("cleverswitch.factory.resolve_feature_index", return_value=None)
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=None)
     result = _make_logi_product(fake_transport, slot=1, role="mouse", name="MX Master")
     assert result is None
 
 
 def test_make_logi_product_returns_logi_product_for_mouse(mocker, fake_transport):
     mocker.patch("cleverswitch.factory.resolve_feature_index", return_value=3)
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=(3, 0))
     result = _make_logi_product(fake_transport, slot=2, role="mouse", name="MX Master")
     assert result is not None
     assert result.slot == 2
     assert result.role == "mouse"
     assert result.change_host_feat_idx == 3
     assert result.divert_feat_idx is None
+    assert result.num_hosts == 3
 
 
 def test_make_logi_product_resolves_reprog_controls_for_keyboard(mocker, fake_transport):
@@ -28,6 +31,7 @@ def test_make_logi_product_resolves_reprog_controls_for_keyboard(mocker, fake_tr
         "cleverswitch.factory.resolve_feature_index",
         side_effect=[3, 4],  # CHANGE_HOST=3, REPROG=4
     )
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=(3, 0))
     result = _make_logi_product(fake_transport, slot=1, role="keyboard", name="MX Keys")
     assert result is not None
     assert result.change_host_feat_idx == 3
@@ -39,11 +43,21 @@ def test_make_logi_product_returns_none_when_keyboard_lacks_reprog(mocker, fake_
         "cleverswitch.factory.resolve_feature_index",
         side_effect=[3, None],  # CHANGE_HOST=3, REPROG missing
     )
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=(3, 0))
     result = _make_logi_product(fake_transport, slot=1, role="keyboard", name="MX Keys")
     assert result is None
 
 
 def test_make_logi_product_name_is_preserved(mocker, fake_transport):
     mocker.patch("cleverswitch.factory.resolve_feature_index", return_value=2)
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=(2, 0))
     result = _make_logi_product(fake_transport, slot=3, role="mouse", name="MX Anywhere 3")
     assert result.name == "MX Anywhere 3"
+
+
+def test_make_logi_product_handles_none_host_info(mocker, fake_transport):
+    mocker.patch("cleverswitch.factory.resolve_feature_index", return_value=3)
+    mocker.patch("cleverswitch.factory.get_host_info", return_value=None)
+    result = _make_logi_product(fake_transport, slot=2, role="mouse", name="MX Master")
+    assert result is not None
+    assert result.num_hosts == 0

--- a/tests/test_listeners.py
+++ b/tests/test_listeners.py
@@ -44,7 +44,7 @@ from cleverswitch.listeners import (
     _undivert_all_es_keys,
     parse_message,
 )
-from cleverswitch.model import ConnectionEvent, ExternalUndivertEvent, HostChangeEvent, LogiProduct, ProductEntry
+from cleverswitch.model import ConnectionEvent, DisconnectionEvent, ExternalUndivertEvent, HostChangeEvent, LogiProduct, ProductEntry
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -219,14 +219,33 @@ def test_parse_message_returns_none_for_unknown_cid_in_long_msg():
     assert not isinstance(parse_message(raw, products), HostChangeEvent)
 
 
-def test_parse_message_returns_none_for_dj_pairing():
-    """DJ parsing is handled at receiver level; parse_message only handles REPORT_LONG."""
+def test_parse_message_returns_connection_event_for_dj_pairing():
     raw = _dj_msg(slot=2, feature_id=DJ_DEVICE_PAIRING, address=0x00)
-    assert parse_message(raw) is None
+    event = parse_message(raw)
+    assert isinstance(event, ConnectionEvent)
+    assert event.slot == 2
 
 
-def test_parse_message_returns_none_for_dj_pairing_disconnected():
+def test_parse_message_returns_disconnection_event_for_dj_pairing_disconnected():
     raw = _dj_msg(slot=3, feature_id=DJ_DEVICE_PAIRING, address=0x40)
+    event = parse_message(raw)
+    assert isinstance(event, DisconnectionEvent)
+    assert event.slot == 3
+
+
+def test_parse_message_returns_disconnection_event_for_hid_device_pairing_disconnect():
+    from cleverswitch.hidpp.constants import HID_DEVICE_PAIRING
+
+    raw = bytes([REPORT_SHORT, 5, HID_DEVICE_PAIRING, 0x10, 0x41, 0x80, 0xB3])
+    event = parse_message(raw)
+    assert isinstance(event, DisconnectionEvent)
+    assert event.slot == 5
+
+
+def test_parse_message_returns_none_for_hid_device_pairing_connect():
+    from cleverswitch.hidpp.constants import HID_DEVICE_PAIRING
+
+    raw = bytes([REPORT_SHORT, 5, HID_DEVICE_PAIRING, 0x10, 0x01, 0x80, 0xB3])
     assert parse_message(raw) is None
 
 


### PR DESCRIPTION
Some Logitech keyboards (e.g. MX Keys for Business) have Easy-Switch CIDs marked as non-divertable (flags=0x04), so the existing CID divert approach cannot intercept host-switch button presses. This adds an alternative detection method using HID++ 1.0 pairing notifications (report 0x10, sub_id 0x41) and DJ disconnect reports (report 0x20).

Changes:
- Detect device disconnect via HID_DEVICE_PAIRING short reports (macOS Bolt) and DJ_DEVICE_PAIRING disconnect reports (Linux)
- On disconnect, send CHANGE_HOST to all other connected devices
- On reconnect, attempt to bring back disconnected devices
- Query and store host info (numHosts) during device detection
- Increase default HID++ request timeout from 500ms to 2000ms to accommodate slower-responding devices through Bolt receivers