### PR TITLE
Harden device discovery against shared-receiver contention

### DIFF
--- a/src/cleverswitch/subscriber/info_task_orchestrator.py
+++ b/src/cleverswitch/subscriber/info_task_orchestrator.py
@@ -1,4 +1,5 @@
 import logging
+import threading
 
 from ..event.info_task_progress_event import InfoTaskProgressEvent
 from ..registry.logi_device_registry import LogiDeviceRegistry
@@ -15,6 +16,10 @@ from ..topic.topics import Topics
 from .task.constants import Task
 
 log = logging.getLogger(__name__)
+
+RETRY_BASE_DELAY = 0.5
+RETRY_MAX_DELAY = 10.0
+RETRY_MAX_ATTEMPTS = 5
 
 _TASK_FACTORIES = {
     Task.Feature.Name.CID_REPORTING: CidReportingFeatureTask,
@@ -33,6 +38,7 @@ class InfoTaskOrchestrator(Subscriber):
         self._device_registry = device_registry
         self._topics = topics
         self._announced: set[int] = set()  # wpids already logged as fully discovered
+        self._retry_attempts: dict[tuple[int, str], int] = {}
         topics.info_progress.subscribe(self)
 
     def notify(self, event) -> None:
@@ -42,6 +48,7 @@ class InfoTaskOrchestrator(Subscriber):
     def _handle_progress(self, event: InfoTaskProgressEvent) -> None:
         device = event.device
         if event.success:
+            self._retry_attempts.pop((device.slot, event.step_name), None)
             if not device.pending_steps and device.wpid not in self._announced:
                 self._announced.add(device.wpid)
                 if device.friendly_name is None and device.name is not None:
@@ -49,5 +56,27 @@ class InfoTaskOrchestrator(Subscriber):
                 log.info(f"Device fully discovered: {device}")
         else:
             if device.connected:
-                log.debug(f"Retrying step={event.step_name} slot={device.slot}")
-                _TASK_FACTORIES[event.step_name](device, self._topics).start()
+                self._schedule_retry(device, event.step_name)
+
+    def _schedule_retry(self, device, step_name: str) -> None:
+        key = (device.slot, step_name)
+        attempt = self._retry_attempts.get(key, 0)
+        if attempt >= RETRY_MAX_ATTEMPTS:
+            log.warning(
+                f"Giving up on step={step_name} for wpid=0x{device.wpid:04X} "
+                f"slot={device.slot} after {RETRY_MAX_ATTEMPTS} attempts"
+            )
+            return
+        self._retry_attempts[key] = attempt + 1
+        delay = min(RETRY_BASE_DELAY * (2**attempt), RETRY_MAX_DELAY)
+        log.debug(
+            f"Retrying step={step_name} slot={device.slot} attempt={attempt + 1}/{RETRY_MAX_ATTEMPTS} in {delay}s"
+        )
+        timer = threading.Timer(delay, self._fire_retry, args=(device, step_name))
+        timer.daemon = True
+        timer.start()
+
+    def _fire_retry(self, device, step_name: str) -> None:
+        if not device.connected:
+            return
+        _TASK_FACTORIES[step_name](device, self._topics).start()

--- a/src/cleverswitch/subscriber/task/get_device_friendly_name_task.py
+++ b/src/cleverswitch/subscriber/task/get_device_friendly_name_task.py
@@ -56,8 +56,13 @@ class GetDeviceFriendlyNameTask(InfoTask):
             chars.extend(chunk)
 
         if len(chars) == name_len:
-            self._device.friendly_name = bytes(chars).decode("utf-8", errors="replace")
-            log.debug(f"wpid=0x{self._device.wpid:04X}: friendly_name={self._device.friendly_name}")
-            self._device.pending_steps.discard(self._step_name)
+            decoded = bytes(chars).decode("utf-8", errors="replace").rstrip("\x00").strip()
+            if not decoded or all(c == "\x00" or c.isspace() or not c.isprintable() for c in decoded):
+                log.debug(f"wpid=0x{self._device.wpid:04X}: discarding corrupted friendly name read")
+                self._device.friendly_name = None
+            else:
+                self._device.friendly_name = decoded
+                log.debug(f"wpid=0x{self._device.wpid:04X}: friendly_name={self._device.friendly_name}")
+                self._device.pending_steps.discard(self._step_name)
         else:
             self._device.friendly_name = None

--- a/src/cleverswitch/subscriber/task/get_device_name_task.py
+++ b/src/cleverswitch/subscriber/task/get_device_name_task.py
@@ -53,8 +53,13 @@ class GetDeviceNameTask(InfoTask):
             chars.extend(chunk)
 
         if len(chars) == name_len:
-            self._device.name = bytes(chars).decode("utf-8", errors="replace")
-            log.debug(f"wpid=0x{self._device.wpid:04X}: name={self._device.name}")
-            self._device.pending_steps.discard(self._step_name)
+            decoded = bytes(chars).decode("utf-8", errors="replace").rstrip("\x00").strip()
+            if not decoded or all(c == "\x00" or c.isspace() or not c.isprintable() for c in decoded):
+                log.debug(f"wpid=0x{self._device.wpid:04X}: discarding corrupted name read")
+                self._device.name = None
+            else:
+                self._device.name = decoded
+                log.debug(f"wpid=0x{self._device.wpid:04X}: name={self._device.name}")
+                self._device.pending_steps.discard(self._step_name)
         else:
             self._device.name = None

--- a/tests/cleverswitch/subscriber/task/test_get_device_friendly_name_task.py
+++ b/tests/cleverswitch/subscriber/task/test_get_device_friendly_name_task.py
@@ -20,7 +20,10 @@ FRIENDLY_IDX = 3
 
 def _make_device(friendly_name=None, pending=None, features=None):
     d = LogiDevice(
-        wpid=0x407B, pid=PID, slot=SLOT, role="keyboard",
+        wpid=0x407B,
+        pid=PID,
+        slot=SLOT,
+        role="keyboard",
         available_features=features if features is not None else {FEATURE_DEVICE_FRIENDLY_NAME: FRIENDLY_IDX},
     )
     d.friendly_name = friendly_name
@@ -71,10 +74,10 @@ def test_assembles_friendly_name_from_multiple_chunks():
     task = GetDeviceFriendlyNameTask(device, topics)
 
     # 20-char name needs two fn=1 calls: byteIndex=0 (15 bytes), byteIndex=15 (5 bytes)
-    full_name = b"MX Master 3S Keys   "  # 20 chars
+    full_name = b"MX Master 3S Mouse!!"  # 20 chars
     name_len = len(full_name)
-    first_chunk = full_name[:15]  # "MX Master 3S Ke"
-    second_chunk = full_name[15:]  # "ys   "
+    first_chunk = full_name[:15]  # "MX Master 3S Mo"
+    second_chunk = full_name[15:]  # "use!!"
 
     task._response_queue.put(_response(bytes([name_len, 30, name_len])))
     # Each fn=1 response: byte 0 = echoed byteIndex, bytes 1..15 = chunk
@@ -176,3 +179,31 @@ def test_chunk_error_leaves_friendly_name_none():
     task.doTask()
 
     assert device.friendly_name is None
+
+
+def test_strips_trailing_nuls_from_good_friendly_name():
+    device = _make_device(pending={Task.Name.GET_DEVICE_FRIENDLY_NAME})
+    topics = _make_topics()
+    task = GetDeviceFriendlyNameTask(device, topics)
+
+    name = b"MX Keys\x00\x00"
+    task._response_queue.put(_response(bytes([len(name), 15, len(name)])))
+    task._response_queue.put(_response(bytes([0]) + name))
+    task.doTask()
+
+    assert device.friendly_name == "MX Keys"
+    assert Task.Name.GET_DEVICE_FRIENDLY_NAME not in device.pending_steps
+
+
+def test_rejects_all_nul_friendly_name_and_keeps_step_pending():
+    device = _make_device(pending={Task.Name.GET_DEVICE_FRIENDLY_NAME})
+    topics = _make_topics()
+    task = GetDeviceFriendlyNameTask(device, topics)
+
+    name = b"\x00\x00\x00\x00"
+    task._response_queue.put(_response(bytes([len(name), 15, len(name)])))
+    task._response_queue.put(_response(bytes([0]) + name))
+    task.doTask()
+
+    assert device.friendly_name is None
+    assert Task.Name.GET_DEVICE_FRIENDLY_NAME in device.pending_steps

--- a/tests/cleverswitch/subscriber/task/test_get_device_name_task.py
+++ b/tests/cleverswitch/subscriber/task/test_get_device_name_task.py
@@ -20,7 +20,10 @@ NAME_IDX = 5
 
 def _make_device(name=None, pending=None, features=None):
     d = LogiDevice(
-        wpid=0x407B, pid=PID, slot=SLOT, role="keyboard",
+        wpid=0x407B,
+        pid=PID,
+        slot=SLOT,
+        role="keyboard",
         available_features=features if features is not None else {FEATURE_DEVICE_TYPE_AND_NAME: NAME_IDX},
         name=name,
     )
@@ -40,7 +43,14 @@ def _make_topics():
 
 
 def _response(payload: bytes):
-    return HidppResponseEvent(slot=SLOT, pid=PID, feature_index=0, function=0, sw_id=GET_DEVICE_NAME_SW_ID, payload=payload + bytes(16 - len(payload)))
+    return HidppResponseEvent(
+        slot=SLOT,
+        pid=PID,
+        feature_index=0,
+        function=0,
+        sw_id=GET_DEVICE_NAME_SW_ID,
+        payload=payload + bytes(16 - len(payload)),
+    )
 
 
 def test_reads_device_name():
@@ -49,8 +59,8 @@ def test_reads_device_name():
     task = GetDeviceNameTask(device, topics)
 
     name = b"MX Keys"
-    task._response_queue.put(_response(bytes([len(name)])))       # count response
-    task._response_queue.put(_response(name))                      # name chunk
+    task._response_queue.put(_response(bytes([len(name)])))  # count response
+    task._response_queue.put(_response(name))  # name chunk
     task.doTask()
 
     assert device.name == "MX Keys"
@@ -64,11 +74,11 @@ def test_assembles_name_from_multiple_chunks():
 
     # 17-char name forces two requests: first fills the 16-byte payload, second fetches the last char
     name = b"MX Master 3S Key"  # 16 chars in first chunk
-    last = b"s"                 # 1 char in second chunk (total 17)
+    last = b"s"  # 1 char in second chunk (total 17)
     full = name + last
     task._response_queue.put(_response(bytes([len(full)])))
-    task._response_queue.put(_response(name))    # charIndex=0, fills all 16 payload bytes
-    task._response_queue.put(_response(last))    # charIndex=16, 1 remaining char
+    task._response_queue.put(_response(name))  # charIndex=0, fills all 16 payload bytes
+    task._response_queue.put(_response(last))  # charIndex=16, 1 remaining char
     task.doTask()
 
     assert device.name == "MX Master 3S Keys"
@@ -139,3 +149,45 @@ def test_sets_name_none_on_chunk_error():
     task.doTask()
 
     assert device.name is None
+
+
+def test_strips_trailing_nuls_from_good_name():
+    device = _make_device(pending={Task.Name.GET_DEVICE_NAME})
+    topics = _make_topics()
+    task = GetDeviceNameTask(device, topics)
+
+    name = b"MX Keys\x00\x00\x00"
+    task._response_queue.put(_response(bytes([len(name)])))
+    task._response_queue.put(_response(name))
+    task.doTask()
+
+    assert device.name == "MX Keys"
+    assert Task.Name.GET_DEVICE_NAME not in device.pending_steps
+
+
+def test_rejects_all_nul_name_and_keeps_step_pending():
+    device = _make_device(pending={Task.Name.GET_DEVICE_NAME})
+    topics = _make_topics()
+    task = GetDeviceNameTask(device, topics)
+
+    name = b"\x00\x00\x00\x00"
+    task._response_queue.put(_response(bytes([len(name)])))
+    task._response_queue.put(_response(name))
+    task.doTask()
+
+    assert device.name is None
+    assert Task.Name.GET_DEVICE_NAME in device.pending_steps
+
+
+def test_rejects_unprintable_garbage_name_and_keeps_step_pending():
+    device = _make_device(pending={Task.Name.GET_DEVICE_NAME})
+    topics = _make_topics()
+    task = GetDeviceNameTask(device, topics)
+
+    name = bytes([0x01, 0x02, 0x03, 0x04])
+    task._response_queue.put(_response(bytes([len(name)])))
+    task._response_queue.put(_response(name))
+    task.doTask()
+
+    assert device.name is None
+    assert Task.Name.GET_DEVICE_NAME in device.pending_steps

--- a/tests/cleverswitch/subscriber/test_info_task_orchestrator.py
+++ b/tests/cleverswitch/subscriber/test_info_task_orchestrator.py
@@ -51,6 +51,7 @@ def test_logs_fully_discovered_when_no_pending_on_success(caplog):
     orch, topics, _ = _make_orchestrator()
 
     import logging
+
     with caplog.at_level(logging.INFO):
         orch.notify(_progress(device, success=True))
 
@@ -62,31 +63,102 @@ def test_no_log_when_pending_steps_remain_on_success(caplog):
     orch, topics, _ = _make_orchestrator()
 
     import logging
+
     with caplog.at_level(logging.INFO):
         orch.notify(_progress(device, success=True))
 
     assert "fully discovered" not in caplog.text.lower()
 
 
-def test_retries_immediately_when_device_connected():
+def test_schedules_backoff_timer_when_device_connected():
+    device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=True)
+    orch, topics, _ = _make_orchestrator()
+
+    with patch("src.cleverswitch.subscriber.info_task_orchestrator.threading.Timer") as mock_timer_cls:
+        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+
+        mock_timer_cls.assert_called_once()
+        args, kwargs = mock_timer_cls.call_args
+        assert args[0] == 0.5  # first retry uses base delay
+        mock_timer_cls.return_value.start.assert_called_once()
+        assert mock_timer_cls.return_value.daemon is True
+
+
+def test_no_retry_scheduled_when_device_disconnected():
+    device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=False)
+    orch, topics, _ = _make_orchestrator()
+
+    with patch("src.cleverswitch.subscriber.info_task_orchestrator.threading.Timer") as mock_timer_cls:
+        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        mock_timer_cls.assert_not_called()
+
+
+def test_backoff_delay_doubles_each_attempt_and_caps():
+    device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=True)
+    orch, topics, _ = _make_orchestrator()
+
+    delays = []
+    with patch("src.cleverswitch.subscriber.info_task_orchestrator.threading.Timer") as mock_timer_cls:
+        for _ in range(5):
+            orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+            delays.append(mock_timer_cls.call_args[0][0])
+
+    assert delays == [0.5, 1.0, 2.0, 4.0, 8.0]
+
+
+def test_gives_up_after_max_attempts(caplog):
+    import logging
+
+    device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=True)
+    orch, topics, _ = _make_orchestrator()
+
+    with patch("src.cleverswitch.subscriber.info_task_orchestrator.threading.Timer") as mock_timer_cls:
+        for _ in range(5):
+            orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        assert mock_timer_cls.call_count == 5
+
+        with caplog.at_level(logging.WARNING):
+            orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+
+        assert mock_timer_cls.call_count == 5  # no further timer scheduled
+        assert "giving up" in caplog.text.lower()
+
+
+def test_success_resets_retry_attempts():
+    device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=True)
+    orch, topics, _ = _make_orchestrator()
+
+    with patch("src.cleverswitch.subscriber.info_task_orchestrator.threading.Timer") as mock_timer_cls:
+        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        assert mock_timer_cls.call_args[0][0] == 0.5
+
+        # a success on the same step clears the counter
+        device.pending_steps = {Task.Feature.Name.CID_REPORTING}
+        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=True))
+
+        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        assert mock_timer_cls.call_args[0][0] == 0.5  # back to base delay
+
+
+def test_fire_retry_creates_task_when_still_connected():
     device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=True)
     orch, topics, _ = _make_orchestrator()
 
     with patch("src.cleverswitch.subscriber.info_task_orchestrator._TASK_FACTORIES") as mock_factories:
         mock_task = MagicMock()
         mock_factories.__getitem__ = MagicMock(return_value=MagicMock(return_value=mock_task))
-        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        orch._fire_retry(device, Task.Feature.Name.CID_REPORTING)
         mock_task.start.assert_called_once()
 
 
-def test_no_retry_when_device_disconnected():
+def test_fire_retry_skips_when_disconnected_meanwhile():
     device = _make_device(pending={Task.Feature.Name.CID_REPORTING}, connected=False)
     orch, topics, _ = _make_orchestrator()
 
     with patch("src.cleverswitch.subscriber.info_task_orchestrator._TASK_FACTORIES") as mock_factories:
         mock_task = MagicMock()
         mock_factories.__getitem__ = MagicMock(return_value=MagicMock(return_value=mock_task))
-        orch.notify(_progress(device, step_name=Task.Feature.Name.CID_REPORTING, success=False))
+        orch._fire_retry(device, Task.Feature.Name.CID_REPORTING)
         mock_task.start.assert_not_called()
 
 
@@ -95,6 +167,7 @@ def test_logs_fully_discovered_only_once_per_device(caplog):
     orch, topics, _ = _make_orchestrator()
 
     import logging
+
     with caplog.at_level(logging.INFO):
         orch.notify(_progress(device, step_name=Task.Name.GET_DEVICE_NAME, success=True))
         orch.notify(_progress(device, step_name=Task.Name.GET_DEVICE_TYPE, success=True))


### PR DESCRIPTION
When another HID++ host (e.g. Logi Options+) shares the Bolt receiver, its solicited responses/errors interleave with CleverSwitch's, making discovery unreliable — corrupted/NUL device names and a storm of immediately-retried failures.

Two robustness fixes:

- **Exponential backoff on orchestrator retries** (`info_task_orchestrator.py`): failed steps retry with backoff (0.5s→10s, ×2, max 5 attempts per `(slot, step)`) via a daemon timer instead of immediately, eliminating the retry storm. Resets on success; re-checks `device.connected` before firing.
- **Reject corrupted device-name reads** (`get_device_name_task.py`, `get_device_friendly_name_task.py`): an all-NUL/empty/unprintable decode is treated as a failed read (`name=None`, step kept pending to retry) rather than stored; trailing NULs stripped from good names.

New tests added for the backoff/give-up/reset paths and the name validation in both tasks.
