### PR TITLE
Prevent multiple concurrent instances with a file lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.10"
 dependencies = [
     "hid >= 1.0.9 ; sys_platform == 'win32'",  # provides hidapi.dll on Windows; Linux/macOS use system libhidapi
     "pyyaml >= 6.0",
+    "filelock >= 3.12",
     "bleak >= 0.22; sys_platform == 'darwin'",
     "pyobjc-framework-CoreBluetooth ; sys_platform == 'darwin'",
 ]

--- a/src/cleverswitch/cli/cli_module.py
+++ b/src/cleverswitch/cli/cli_module.py
@@ -10,8 +10,9 @@ import threading
 
 from .. import __version__
 from ..discovery.discovery import discover
-from ..errors.errors import CleverSwitchError
+from ..errors.errors import AlreadyRunningError, CleverSwitchError
 from ..setup.app_setup import setup_context
+from ..single_instance import acquire_single_instance_lock
 
 _SYSTEM = platform.system()
 
@@ -21,6 +22,12 @@ def main() -> None:
 
     _setup_logging(args.verbose or args.verbose_extra)
     log = logging.getLogger(__name__)
+
+    try:
+        _instance_lock = acquire_single_instance_lock()  # noqa: F841 — held for process lifetime
+    except AlreadyRunningError:
+        log.error("Another CleverSwitch instance is already running; exiting")
+        sys.exit(0)
 
     app_context = setup_context(args)
 

--- a/src/cleverswitch/errors/errors.py
+++ b/src/cleverswitch/errors/errors.py
@@ -31,3 +31,9 @@ class TransportError(CleverSwitchError):
 
 class ConfigError(CleverSwitchError):
     pass
+
+
+class AlreadyRunningError(CleverSwitchError):
+    """Raised when another CleverSwitch instance already holds the single-instance lock."""
+
+    pass

--- a/src/cleverswitch/single_instance.py
+++ b/src/cleverswitch/single_instance.py
@@ -1,0 +1,29 @@
+"""Single-instance guard.
+
+Prevents two CleverSwitch daemons from running at once and contending over the
+shared Logitech receiver, which corrupts HID++ traffic.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from filelock import FileLock, Timeout
+
+from .errors.errors import AlreadyRunningError
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_LOCK_PATH = Path("~/.config/cleverswitch/cleverswitch.lock").expanduser()
+
+
+def acquire_single_instance_lock(lock_path: Path | None = None) -> FileLock:
+    path = lock_path if lock_path is not None else _DEFAULT_LOCK_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock = FileLock(str(path))
+    try:
+        lock.acquire(timeout=0)
+    except Timeout as e:
+        raise AlreadyRunningError(f"Another CleverSwitch instance already holds {path}") from e
+    return lock

--- a/tests/cleverswitch/cli/test_cli.py
+++ b/tests/cleverswitch/cli/test_cli.py
@@ -8,8 +8,7 @@ import sys
 import pytest
 
 from src.cleverswitch.cli.cli_module import _parse_args, _setup_logging, main
-from src.cleverswitch.errors.errors import CleverSwitchError
-
+from src.cleverswitch.errors.errors import AlreadyRunningError, CleverSwitchError
 
 # ── _parse_args() ─────────────────────────────────────────────────────────────
 
@@ -66,9 +65,10 @@ def test_setup_logging_overrides_to_debug_when_verbose_is_true(mocker):
 def test_main_starts_discovery_thread_in_normal_mode(mocker, monkeypatch):
     monkeypatch.setattr(sys, "argv", ["cleverswitch"])
     mock_context = mocker.MagicMock()
-    mocker.patch("cleverswitch.cli.cli_module.setup_context", return_value=mock_context)
-    mocker.patch("cleverswitch.cli.cli_module._setup_logging")
-    mock_thread_cls = mocker.patch("cleverswitch.cli.cli_module.threading.Thread")
+    mocker.patch("src.cleverswitch.cli.cli_module.setup_context", return_value=mock_context)
+    mocker.patch("src.cleverswitch.cli.cli_module._setup_logging")
+    mocker.patch("src.cleverswitch.cli.cli_module.acquire_single_instance_lock")
+    mock_thread_cls = mocker.patch("src.cleverswitch.cli.cli_module.threading.Thread")
     mock_thread = mock_thread_cls.return_value
 
     main()
@@ -83,9 +83,25 @@ def test_main_exits_with_code_1_on_clever_switch_error(mocker, monkeypatch):
     mock_context = mocker.MagicMock()
     mocker.patch("src.cleverswitch.cli.cli_module.setup_context", return_value=mock_context)
     mocker.patch("src.cleverswitch.cli.cli_module._setup_logging")
+    mocker.patch("src.cleverswitch.cli.cli_module.acquire_single_instance_lock")
     mock_thread_cls = mocker.patch("src.cleverswitch.cli.cli_module.threading.Thread")
     mock_thread_cls.return_value.start.side_effect = CleverSwitchError("boom")
 
     with pytest.raises(SystemExit) as exc:
         main()
     assert exc.value.code == 1
+
+
+def test_main_exits_cleanly_when_another_instance_is_running(mocker, monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["cleverswitch"])
+    mocker.patch("src.cleverswitch.cli.cli_module._setup_logging")
+    mocker.patch(
+        "src.cleverswitch.cli.cli_module.acquire_single_instance_lock",
+        side_effect=AlreadyRunningError("already running"),
+    )
+    mock_setup = mocker.patch("src.cleverswitch.cli.cli_module.setup_context")
+
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 0
+    mock_setup.assert_not_called()

--- a/tests/cleverswitch/test_single_instance.py
+++ b/tests/cleverswitch/test_single_instance.py
@@ -1,0 +1,50 @@
+"""Unit tests for the single-instance guard."""
+
+from __future__ import annotations
+
+import pytest
+from filelock import FileLock
+
+from src.cleverswitch.errors.errors import AlreadyRunningError
+from src.cleverswitch.single_instance import acquire_single_instance_lock
+
+
+def test_first_acquire_succeeds_and_returns_held_lock(tmp_path):
+    lock_path = tmp_path / "cleverswitch.lock"
+
+    lock = acquire_single_instance_lock(lock_path)
+
+    assert isinstance(lock, FileLock)
+    assert lock.is_locked
+    lock.release()
+
+
+def test_second_acquire_raises_already_running(tmp_path):
+    lock_path = tmp_path / "cleverswitch.lock"
+
+    first = acquire_single_instance_lock(lock_path)
+    try:
+        with pytest.raises(AlreadyRunningError):
+            acquire_single_instance_lock(lock_path)
+    finally:
+        first.release()
+
+
+def test_acquire_succeeds_after_first_lock_released(tmp_path):
+    lock_path = tmp_path / "cleverswitch.lock"
+
+    first = acquire_single_instance_lock(lock_path)
+    first.release()
+
+    second = acquire_single_instance_lock(lock_path)
+    assert second.is_locked
+    second.release()
+
+
+def test_acquire_creates_parent_directory(tmp_path):
+    lock_path = tmp_path / "nested" / "dir" / "cleverswitch.lock"
+
+    lock = acquire_single_instance_lock(lock_path)
+
+    assert lock_path.parent.is_dir()
+    lock.release()


### PR DESCRIPTION
Two CleverSwitch daemons running at once contend over the same receiver and corrupt HID++ discovery (same failure mode as an external app sharing it). There's currently no guard — e.g. a duplicate manual launch or a Task Scheduler double-fire.

At startup (before any HID work) CleverSwitch now acquires an exclusive `filelock` at `~/.config/cleverswitch/cleverswitch.lock`. If another instance holds it, it logs and exits cleanly (exit code 0, so a scheduler doesn't flag a recurring failure). The lock auto-releases on process death, so a crash never leaves stale state.

Adds the `filelock` dependency and an `AlreadyRunningError`. Tested.
