### PR TITLE
Sanitize NUL bytes in hook env and support Windows script paths

### DIFF
--- a/src/cleverswitch/hook/hooks.py
+++ b/src/cleverswitch/hook/hooks.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
 
@@ -64,14 +65,20 @@ def fire_disconnect(hooks_cfg: HooksConfig, device_name: str, role: str) -> None
     )
 
 
+_WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
 def _is_file_path(value: str) -> bool:
     """Heuristic: does the string look like a file path rather than a shell command?"""
-    return value.startswith(("/", "~/", "./", "../"))
+    if _WINDOWS_DRIVE_RE.match(value):  # drive-letter path, e.g. C:\... or C:/...
+        return True
+    return value.startswith(("/", "~/", "./", "../", "~\\", ".\\", "..\\", "\\\\"))
 
 
 def _run(hook: HookEntry, extra_env: dict[str, str]) -> None:
     """Run one hook synchronously (called from a worker thread)."""
-    env = {**os.environ, **extra_env}
+    sanitized_env = {k: v.replace("\x00", "") for k, v in extra_env.items()}
+    env = {**os.environ, **sanitized_env}
     expanded = os.path.expanduser(hook.path)
 
     if _is_file_path(hook.path):

--- a/src/cleverswitch/hook/hooks.py
+++ b/src/cleverswitch/hook/hooks.py
@@ -70,9 +70,7 @@ _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 
 def _is_file_path(value: str) -> bool:
     """Heuristic: does the string look like a file path rather than a shell command?"""
-    if _WINDOWS_DRIVE_RE.match(value):  # drive-letter path, e.g. C:\... or C:/...
-        return True
-    return value.startswith(("/", "~/", "./", "../", "~\\", ".\\", "..\\", "\\\\"))
+    return _WINDOWS_DRIVE_RE.match(value) or value.startswith(("/", "~/", "./", "../", "~\\", ".\\", "..\\", "\\\\"))
 
 
 def _run(hook: HookEntry, extra_env: dict[str, str]) -> None:

--- a/tests/cleverswitch/hook/test_hooks.py
+++ b/tests/cleverswitch/hook/test_hooks.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import logging
 import subprocess
 
+from cleverswitch.hook.hooks import _is_file_path, _run, fire, fire_connect, fire_disconnect, fire_switch
 from cleverswitch.model.config.hook_entry import HookEntry
 from cleverswitch.model.config.hooks_config import HooksConfig
-from cleverswitch.hook.hooks import _run, fire, fire_connect, fire_disconnect, fire_switch
 
 # ── fire() ────────────────────────────────────────────────────────────────────
 
@@ -237,3 +237,43 @@ def test_run_command_logs_warning_on_unexpected_exception(mocker, caplog):
         _run(HookEntry(path="broken-command"), {})
 
     assert "failed" in caplog.text
+
+
+# ── _is_file_path() ───────────────────────────────────────────────────────────
+
+
+def test_is_file_path_recognizes_unix_paths():
+    assert _is_file_path("/usr/local/bin/hook.sh")
+    assert _is_file_path("~/hook.sh")
+    assert _is_file_path("./hook.sh")
+    assert _is_file_path("../hook.sh")
+
+
+def test_is_file_path_recognizes_windows_paths():
+    assert _is_file_path("C:\\Users\\me\\hook.ps1")
+    assert _is_file_path("c:/Users/me/hook.ps1")
+    assert _is_file_path(".\\hook.ps1")
+    assert _is_file_path("..\\hook.ps1")
+    assert _is_file_path("~\\hook.ps1")
+    assert _is_file_path("\\\\server\\share\\hook.ps1")
+
+
+def test_is_file_path_treats_commands_as_non_paths():
+    assert not _is_file_path("echo hello")
+    assert not _is_file_path("pwsh.exe C:\\Users\\me\\hook.ps1")
+    assert not _is_file_path("bad-command")
+
+
+def test_run_strips_nul_from_env_values(mocker, tmp_path):
+    script = tmp_path / "hook.sh"
+    script.touch()
+    mock_result = mocker.MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = ""
+    mock_run = mocker.patch("cleverswitch.hook.hooks.subprocess.run", return_value=mock_result)
+
+    _run(HookEntry(path=str(script)), {"CLEVERSWITCH_DEVICE_NAME": "MX\x00 Keys\x00"})
+
+    mock_run.assert_called_once()  # did not raise ValueError: embedded null character
+    _, kwargs = mock_run.call_args
+    assert kwargs["env"]["CLEVERSWITCH_DEVICE_NAME"] == "MX Keys"


### PR DESCRIPTION
Two hook-execution robustness fixes:

- **NUL-safe env**: a device name containing NUL bytes (e.g. from a corrupted read) crashes the hook subprocess with `ValueError: embedded null character`. Hook env values are now stripped of NULs before `subprocess`, so a bad name can never take down a hook.
- **Windows script paths**: `_is_file_path` only recognized Unix-style paths (`/`, `~/`, `./`, `../`), so on Windows a bare script path (`C:\...`) was wrongly run through the shell. It now also recognizes drive-letter, UNC, and backslash-relative paths.

Also fixes the pre-existing `test_run_executes_script_without_shell_when_file_exists` failure on Windows. Tested.
